### PR TITLE
Fixes for bedrock invoke max tokens and for config flow error

### DIFF
--- a/custom_components/bedrock_conversation/bedrock_client.py
+++ b/custom_components/bedrock_conversation/bedrock_client.py
@@ -466,7 +466,7 @@ class BedrockClient:
         await self._ensure_client()
         
         model_id = options.get(CONF_MODEL_ID, DEFAULT_MODEL_ID)
-        max_tokens = options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
+        max_tokens = int(options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = options.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE)
         top_p = options.get(CONF_TOP_P, DEFAULT_TOP_P)
         top_k = options.get(CONF_TOP_K, DEFAULT_TOP_K)

--- a/custom_components/bedrock_conversation/config_flow.py
+++ b/custom_components/bedrock_conversation/config_flow.py
@@ -183,7 +183,8 @@ class BedrockConversationOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        # self.config_entry = config_entry
+        self._conf_app_id: str | None = None
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -230,7 +231,7 @@ class BedrockConversationOptionsFlow(config_entries.OptionsFlow):
                 default=self.config_entry.options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=100, max=100000, step=100, mode=selector.NumberSelectorMode.BOX
+                    min=0, max=100000, step=100, mode=selector.NumberSelectorMode.BOX
                 )
             ),
             vol.Optional(


### PR DESCRIPTION
Fixes for errors when max_tokens gets defined in settings as float, and to avoid errors on newer HA deployments with config flow to avoid errors trying to override a built in resource